### PR TITLE
Fixes issue with methods not being public

### DIFF
--- a/esphome/components/at581x/at581x.h
+++ b/esphome/components/at581x/at581x.h
@@ -17,8 +17,10 @@ class AT581XComponent : public Component, public i2c::I2CDevice {
 #ifdef USE_SWITCH
  protected:
   switch_::Switch *rf_power_switch_{nullptr};
+#endif
 
  public:
+#ifdef USE_SWITCH
   void set_rf_power_switch(switch_::Switch *s) {
     this->rf_power_switch_ = s;
     s->turn_on();


### PR DESCRIPTION
If there's no switch configured the conditional compilation was not adding the necessary `public` modifier and using a `at581x.settings` would fail to compile.

# What does this implement/fix?

If you have a `at581x` device configured but you don't add a `switch` for it compilation failed if trying to use a `at581x.settings` in any automation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  on_boot:
    - priority: 601
      then:
        - at581x.settings:
            id: "Waveradar"
            frequency: 5800MHz
            sensing_distance: 200
            poweron_selfcheck_time: 2s
            protect_time: 1s
            trigger_base: 500ms
            trigger_keep: 10s
            stage_gain: 3
            power_consumption: 70µA

at581x:
  id: "Waveradar"
  address: 0x28

```

Adding this would make it compile:
```
switch:
  - platform: at581x
    name: "Enable Radar"
```


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
